### PR TITLE
[DEV-11040] Don't overwrite custom ssl-context

### DIFF
--- a/caching/project.clj
+++ b/caching/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/caching "2.1.11-SNAPSHOT"
+(defproject org.immutant/caching "2.1.13-SNAPSHOT"
   :description "Create, manage and manipulate Infinispan caches."
   :plugins [[lein-modules "0.3.11"]]
 

--- a/core/project.clj
+++ b/core/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/core "2.1.11-SNAPSHOT"
+(defproject org.immutant/core "2.1.13-SNAPSHOT"
   :description "Utilities shared by Immutant libs."
   :plugins [[lein-modules "0.3.11"]]
 

--- a/immutant/project.clj
+++ b/immutant/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/immutant "2.1.11-SNAPSHOT"
+(defproject org.immutant/immutant "2.1.13-SNAPSHOT"
   :description "A catch-all pom that brings in all Immutant libs."
   :plugins [[lein-modules "0.3.11"]]
   :packaging "pom"

--- a/integration-tests/project.clj
+++ b/integration-tests/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/integs "2.1.11-SNAPSHOT"
+(defproject org.immutant/integs "2.1.13-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :dependencies [[org.immutant/immutant _]
                  [org.immutant/wildfly _]]

--- a/messaging/project.clj
+++ b/messaging/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/messaging "2.1.11-SNAPSHOT"
+(defproject org.immutant/messaging "2.1.13-SNAPSHOT"
   :description "Easily publish and receive messages containing any type of nested data structure to dynamically-created queues and topics."
   :plugins [[lein-modules "0.3.11"]]
 

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/immutant-parent "2.1.11-SNAPSHOT"
+(defproject org.immutant/immutant-parent "2.1.13-SNAPSHOT"
   :description "Parent for all that is Immutant"
   :plugins [[lein-modules "0.3.11"]]
   :packaging "pom"

--- a/scheduling/project.clj
+++ b/scheduling/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/scheduling "2.1.11-SNAPSHOT"
+(defproject org.immutant/scheduling "2.1.13-SNAPSHOT"
   :description "Schedule jobs for execution in the future."
   :plugins [[lein-modules "0.3.11"]]
 

--- a/transactions/project.clj
+++ b/transactions/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/transactions "2.1.11-SNAPSHOT"
+(defproject org.immutant/transactions "2.1.13-SNAPSHOT"
   :description "Provides support for distributed (XA) transactions."
   :plugins [[lein-modules "0.3.11"]]
 

--- a/web/project.clj
+++ b/web/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/web "2.1.11-SNAPSHOT"
+(defproject org.immutant/web "2.1.13-SNAPSHOT"
   :description "Serve web requests using Ring handlers, Servlets, or Undertow HttpHandlers."
   :plugins [[lein-modules "0.3.11"]]
   :java-source-paths ["src"]

--- a/web/src/immutant/web/internal/undertow.clj
+++ b/web/src/immutant/web/internal/undertow.clj
@@ -145,7 +145,7 @@
   (body [exchange]               (when (.isBlocking exchange) (.getInputStream exchange)))
   (context [exchange]            (.getResolvedPath exchange))
   (path-info [exchange]          (path-info' exchange))
-  (ssl-client-cert [exchange]    (.getPeerCertificateChain (.getSslSessionInfo (.getConnection exchange))))
+  (ssl-client-cert [exchange]    (.. exchange getConnection getSslSessionInfo getPeerCertificates))
 
   ring/RingResponse
   (set-status [exchange status]       (.setResponseCode exchange status))

--- a/web/src/immutant/web/undertow.clj
+++ b/web/src/immutant/web/undertow.clj
@@ -109,10 +109,12 @@
   "Assoc an SSLContext given a keystore and a truststore, which may be
   either actual KeyStore instances, or paths to them. If truststore is
   ommitted, the keystore is assumed to fulfill both roles"
-  [{:keys [keystore key-password truststore trust-password] :as options}]
-  (-> options
-    (assoc :ssl-context (keystore->ssl-context options))
-    (dissoc :keystore :key-password :truststore :trust-password)))
+  [{:keys [keystore key-password truststore trust-password ssl-context] :as options}]
+  (if ssl-context
+    options
+    (-> options
+        (assoc :ssl-context (keystore->ssl-context options))
+        (dissoc :keystore :key-password :truststore :trust-password))))
 
 (def options
   "Takes a map of Undertow-specific options and replaces them with an

--- a/wildfly/project.clj
+++ b/wildfly/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject org.immutant/wildfly "2.1.11-SNAPSHOT"
+(defproject org.immutant/wildfly "2.1.13-SNAPSHOT"
   :description "Utility functions only useful within a WildFly container."
   :plugins [[lein-modules "0.3.11"]]
 


### PR DESCRIPTION
This addresses a couple issues we ran into while working on DEV-11040.

Specifically:
- Passing an `:ssl-context` just flat out didn't work. This is addressed in https://github.com/kirasystems/immutant/pull/3/commits/f078de21154e0fe1206335ebaa1eb708a98a6c96.
- The client certificate chain passed down via `:ssl-client-cert` on the request map are now of the newer `java.security.cert.Certificate` flavour. Done in https://github.com/kirasystems/immutant/pull/3/commits/2816303c58425f00ac1218b2bcf412ed1eaea74c.